### PR TITLE
Add DSTC mathematical verification suite scaffolding

### DIFF
--- a/proofs/README.md
+++ b/proofs/README.md
@@ -1,0 +1,25 @@
+# DSTC Mathematical Verification Suite
+
+This repository provides automated mathematical verification and numerical experiments for the **Dynamic Subjective Theory of Consciousness (DSTC)** using Codex/GPT-based symbolic engines.
+
+## 📌 Verification Targets
+
+| ID     | Formula / Concept                           | File                            | Purpose |
+|--------|---------------------------------------------|----------------------------------|---------|
+| Eq-1   | Kuramoto oscillator dynamics                | `kuramoto_simulation.py`         | Simulate λ(t) |
+| Eq-5   | Strength synchronization: λ = r²            | `kuramoto_simulation.py`         | λ(t) time series |
+| Eq-9   | vMF estimation of semantic sync (κ̂)        | `von_mises_kappa_check.ipynb`    | λ_sem validation |
+| Eq-17  | Φ_G ≈ -N log(1 - λ)                         | `phi_verification.ipynb`         | IIT connection |
+| App-A  | Covariance matrix & Φ_G derivation          | `phi_verification.ipynb`         | eigenvalue check |
+| App-B  | Energy landscape V(r)                       | `energy_landscape_plot.ipynb`    | visual & symbolic |
+| App-C  | Dynamic noise feedback D(t) = D₀·g(χ(t))    | `dynamic_noise_control.ipynb`    | verify Resync |
+| App-D  | MPC formulation of Resync                   | `resync_mpc_formulation.md`      | symbolic MPC modeling |
+
+## ⚙️ Libraries Required
+
+```bash
+pip install numpy scipy matplotlib sympy jupyter
+Optional for symbolic: sympy, torch, sklearn, networkx
+
+For notebooks: jupyter or VSCode + Jupyter plugin
+```

--- a/proofs/dynamic_noise_control.ipynb
+++ b/proofs/dynamic_noise_control.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dynamic Noise Control\n",
+    "\n",
+    "Placeholder notebook for verifying dynamic noise feedback \n",
+    "\\( D(t) = D_0 \cdot g(\chi(t)) \\) in the Resync protocol." 
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/proofs/energy_landscape_plot.ipynb
+++ b/proofs/energy_landscape_plot.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Energy Landscape Plot\n",
+    "\n",
+    "Placeholder notebook for visualizing the energy landscape \n",
+    "\\( V(r) \\) associated with DSTC synchronization." 
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/proofs/kuramoto_simulation.py
+++ b/proofs/kuramoto_simulation.py
@@ -1,0 +1,33 @@
+"""
+Simulate N Kuramoto oscillators and compute strength synchronization λ(t).
+
+Verification target:
+  λ(t) = |mean(exp(iθ))|²
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Parameters
+N = 100
+T = 1000
+dt = 0.05
+K = 1.5
+omega = np.random.normal(0, 1, N)
+theta = np.random.uniform(0, 2*np.pi, N)
+lambda_t = []
+
+# Simulation loop
+for _ in range(T):
+    theta += (omega + K/N * np.sum(np.sin(theta[:,None] - theta), axis=1)) * dt
+    r = np.abs(np.mean(np.exp(1j * theta)))
+    lambda_t.append(r**2)
+
+# Plot
+t = np.arange(T) * dt
+plt.plot(t, lambda_t)
+plt.xlabel('Time')
+plt.ylabel('λ(t)')
+plt.title('Strength Synchronization over Time')
+plt.grid()
+plt.show()

--- a/proofs/phi_verification.ipynb
+++ b/proofs/phi_verification.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "Objective:\n",
+    "Verify the approximation Φ_G ≈ -N log(1 - λ)\n",
+    "using λ(t) values from Kuramoto model.\n",
+    "\n",
+    "Assume:\n",
+    "- N = 100\n",
+    "- λ ∈ (0, 1)\n",
+    "\n",
+    "Steps:\n",
+    "1. Define Φ_G(λ) = -N * log(1 - λ)\n",
+    "2. Plot Φ_G vs λ\n",
+    "3. Optional: Overlay simulated λ(t) from kuramoto_simulation.py\n",
+    "\"\"\"\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "N = 100\n",
+    "lambda_vals = np.linspace(0.001, 0.99, 100)\n",
+    "phi_vals = -N * np.log(1 - lambda_vals)\n",
+    "\n",
+    "plt.plot(lambda_vals, phi_vals)\n",
+    "plt.xlabel('λ')\n",
+    "plt.ylabel('Φ_G')\n",
+    "plt.title('Verification of Φ_G ≈ -N log(1 - λ)')\n",
+    "plt.grid()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/proofs/resync_mpc_formulation.md
+++ b/proofs/resync_mpc_formulation.md
@@ -1,0 +1,31 @@
+# MPC Formulation of Resync Protocol
+
+We define Resync as a Model Predictive Control (MPC) problem:
+
+## Variables
+
+- State vector:
+  $$ \mathbf{x}(t) = [\lambda(t), \lambda_{\text{semantic}}(t), \chi(t)]^T $$
+
+- Control input:
+  $$ \mathbf{u}(t) = [\delta K(t), \delta D(t)]^T $$
+
+## Cost Function
+
+Minimize:
+$$
+J = \int_t^{t+T_p} \left( \|\mathbf{x}(\tau) - \mathbf{x}_{\text{target}}\|_Q^2
++ \|\mathbf{u}(\tau)\|_R^2 \right) d\tau
+$$
+
+## Constraints
+
+$$
+\mathbf{u}_{\min} \leq \mathbf{u}(t) \leq \mathbf{u}_{\max}
+$$
+
+Where:
+- Q, R: weighting matrices
+- T_p: prediction horizon
+
+> This formulation allows implementation using `cvxpy`, `casadi`, or symbolic solvers.

--- a/proofs/von_mises_kappa_check.ipynb
+++ b/proofs/von_mises_kappa_check.ipynb
@@ -1,0 +1,28 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# von Mises–Fisher Kappa Check\n",
+    "\n",
+    "Placeholder notebook for validating semantic synchronization using the von Mises–Fisher distribution." 
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Introduce `proofs` directory housing scripts and notebooks for validating Dynamic Subjective Theory of Consciousness.
- Implement Kuramoto oscillator simulation and Φ_G approximation notebook.
- Provide MPC formulation and placeholder notebooks for future DSTC experiments.

## Testing
- `python -m py_compile proofs/kuramoto_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_68945edc679c8323a5acb70d9f3f7650